### PR TITLE
게임 전체의 이벤트 처리 방식 변경

### DIFF
--- a/engine/button.py
+++ b/engine/button.py
@@ -1,28 +1,28 @@
-from typing import Any, Callable
 import pygame
+from engine.event import Event, EventHandler
 from engine.gameobject import GameObject
 from engine.world import World
 
 class Button(GameObject):
     font: pygame.font.Font
 
-    on_click: Callable[[], None]
+    on_click: EventHandler
     
     _is_hovered: bool
     _rendered_text: pygame.Surface
 
-    def __init__(self, text: str, rect: pygame.Rect, font: pygame.font.Font, on_click: Callable[[Any], None] | None = None):
+    def __init__(self, text: str, rect: pygame.Rect, font: pygame.font.Font, on_click: EventHandler | None = None):
+        super().__init__()
+
         self.rect = rect
         self.font = font
         self.on_click = on_click
         self._is_hovered = False
         
         self.set_text(text)
-        if self.on_click is not None:
-            World.events.on('click', self.handle_click)
-
-    def update(self):
-        self._is_hovered = self.rect.collidepoint(pygame.mouse.get_pos())
+        self.on('mouse_down', self.handle_mouse_down)
+        self.on('mouse_move', self.handle_mouse_move)
+        self.on('mouse_out', self.handle_mouse_out)
 
     def render(self, surface: pygame.Surface):
         if self._is_hovered:
@@ -35,6 +35,21 @@ class Button(GameObject):
     def set_text(self, text: str):
         self._rendered_text = self.font.render(text, True, pygame.Color('black'))
 
-    def handle_click(self, event):
+    def handle_mouse_down(self, event: Event):
         if self.rect.collidepoint(pygame.mouse.get_pos()):
             self.on_click(event)
+            event.stopPropagation()
+    
+    def handle_mouse_move(self, event: Event):
+        if event.target is self:
+            return
+        if 'pos' in event.data:
+            self._is_hovered = self.rect.collidepoint(event.data.get('pos'))
+        if self._is_hovered:
+            e = Event(None)
+            e.target = self
+            self.parent.emit('mouse_out', e)
+            event.stopPropagation()
+
+    def handle_mouse_out(self, event: Event):
+        self._is_hovered = False

--- a/engine/event.py
+++ b/engine/event.py
@@ -1,13 +1,33 @@
-from typing import Callable
+from __future__ import annotations
+from typing import Any, Callable, Self
 
+EventData = dict[str, Any] | None
 
-class EventEmiiter():
-    event_map: dict[str, list[Callable]]
+class Event():
+    data: EventData
+    is_propagation_stopped: bool
+    target: EventEmitter | None
 
-    def __init__(self) -> None:
+    def __init__(self, data: EventData) -> None:
+        self.is_propagation_stopped = False
+
+        self.data = data
+        self.target = None
+    
+    def stopPropagation(self):
+        self.is_propagation_stopped = True
+
+EventHandler = Callable[[Event], None]
+
+class EventEmitter():
+    event_map: dict[str, list[EventHandler]]
+    parent: Self | None
+
+    def __init__(self, parent: Self | None = None) -> None:
         self.event_map = {}
+        self.parent = parent
         
-    def on(self, event_name: str, handler: Callable):
+    def on(self, event_name: str, handler: EventHandler):
         if handler is None:
             return
         if event_name in self.event_map:
@@ -15,7 +35,10 @@ class EventEmiiter():
         else:
             self.event_map[event_name] = [handler]
 
-    def emit(self, event_name: str, event_data):
+    def emit(self, event_name: str, event: Event):
+        if event.is_propagation_stopped:
+            return
+
         if event_name in self.event_map:
             for handler in self.event_map[event_name]:
-                handler(event_data)
+                handler(event)

--- a/engine/gameobject.py
+++ b/engine/gameobject.py
@@ -1,11 +1,13 @@
 import pygame
 import abc
 
-class GameObject(abc.ABC):
+from engine.event import EventEmitter
+
+class GameObject(EventEmitter, abc.ABC):
     rect: pygame.Rect
 
     def __init__(self):
-        pass
+        super().__init__()
 
     def update(self):
         pass

--- a/engine/gameobjectcontainer.py
+++ b/engine/gameobjectcontainer.py
@@ -1,19 +1,41 @@
 import abc
 import pygame
+from engine.event import Event
 
 from engine.gameobject import GameObject
 
-class GameObjectContainer(abc.ABC):
-    children: list[GameObject]
+class GameObjectContainer(GameObject, abc.ABC):
+    _children: list[GameObject]
 
     def __init__(self):
         super().__init__()
-        self.children = []
+        self._children = []
 
     def update(self):
-        for child in self.children:
+        for child in self._children:
             child.update()
 
     def render(self, surface: pygame.Surface):
-        for child in self.children:
+        for child in self._children:
             child.render(surface)
+
+    def add_child(self, child: GameObject):
+        self._children.append(child)
+        child.parent = self
+    
+    def add_children(self, children: list[GameObject]):
+        for child in children:
+            self.add_child(child)
+
+    def remove_child(self, child: GameObject):
+        self._children.remove(child)
+        child.parent = None
+    
+    def emit(self, event_name: str, event: Event):
+        super().emit(event_name, event)
+        for child in reversed(self._children):
+            if event.target is child:
+                continue
+            if event.is_propagation_stopped:
+                break
+            child.emit(event_name, event)

--- a/engine/sprite.py
+++ b/engine/sprite.py
@@ -6,6 +6,7 @@ class Sprite(GameObject):
     image: pygame.Surface
 
     def __init__(self, surface: pygame.Surface):
+        super().__init__()
         self.image = surface
         self.rect = surface.get_rect()
 

--- a/engine/text.py
+++ b/engine/text.py
@@ -8,6 +8,7 @@ class Text(GameObject):
     color: pygame.Color
     
     def __init__(self, text: str, position: pygame.Vector2, font: pygame.font.Font, color: pygame.Color):
+        super().__init__()
         self.text = text
         self.position = position
         self.font = font

--- a/engine/world.py
+++ b/engine/world.py
@@ -1,11 +1,9 @@
 import pygame
 import sys
-from engine.event import EventEmiiter
+from engine.event import Event
 from engine.scene import SceneDirector
 
 class World():
-    events: EventEmiiter = EventEmiiter()
-
     screen: pygame.Surface
     director: SceneDirector
     clock: pygame.time.Clock
@@ -35,9 +33,11 @@ class World():
 
     def handle_event(self):
         for event in pygame.event.get():
-            if event.type == pygame.QUIT:
-                pygame.quit()
-                sys.exit()
-            if event.type == pygame.MOUSEBUTTONDOWN:
-                World.events.emit('click', event)
-                
+            match event.type:
+                case pygame.QUIT:
+                    pygame.quit()
+                    sys.exit()
+                case pygame.MOUSEBUTTONDOWN:
+                    self.director.get_current().emit('mouse_down', Event(event.dict))
+                case pygame.MOUSEMOTION:
+                    self.director.get_current().emit('mouse_move', Event(event.dict))

--- a/game/scene/ingame.py
+++ b/game/scene/ingame.py
@@ -13,7 +13,7 @@ class InGameScene(Scene):
         from game.scene.menu import MenuScene
         menu_button = Button('Back to menu', pygame.Rect(10, 10, 200, 100), pygame.font.SysFont('Arial', 20), lambda event: self.world.director.change_scene(MenuScene(self.world)))
         
-        self.children.extend([
+        self.add_children([
             self.sprite,
             menu_button
         ])

--- a/game/scene/menu.py
+++ b/game/scene/menu.py
@@ -17,7 +17,7 @@ class MenuScene(Scene):
         sprite.rect.move_ip(200, 200)
 
         from game.scene.ingame import InGameScene
-        self.children.extend([
+        self.add_children([
             Button('Start', button_rect.move(20, 20), font, on_click=lambda event: self.world.director.change_scene(InGameScene(self.world))),
             Button('Settings', button_rect.move(20, 110), font),
             Button('Exit', button_rect.move(20, 200), font, on_click=lambda event: sys.exit()),


### PR DESCRIPTION
Button이 World에서 직접 이벤트를 받아오는 대신 Scene을 시작으로 디스플레이 트리를 통해 전파된 이벤트를 수신하게 변경하여 활성화되지 않은 Scene의 객체가 마우스 이벤트에 반응하는 것을 막고 가비지 컬렉션의 대상이 되도록 수정했습니다.

또한 이벤트 기반으로 제대로 된 커서 움직임 처리를 구현하여 겹쳐있는 객체가 중복으로 mouse_down 이벤트 등을 수신하는 문제를 막았습니다.

Fix #3
Fix #5 