### PR TITLE
본인 이름 표시, 마스터 볼륨 추가, 카드 애니메이션 색약모드 수정

### DIFF
--- a/game/audio_player.py
+++ b/game/audio_player.py
@@ -59,5 +59,6 @@ class AudioPlayer:
 
     def handle_settings_change(self, event: Event):
         settings: Settings = event.target
-        self.set_bgm_volume(settings.bgm_volume)
-        self.set_effect_volume(settings.effect_volume)
+        self.set_bgm_volume(settings.bgm_volume / 100.0)
+        self.set_effect_volume(settings.effect_volume / 100.0)
+        self.set_volume(settings.master_volume / 100.0)

--- a/game/audio_player.py
+++ b/game/audio_player.py
@@ -28,7 +28,7 @@ class AudioPlayer:
         ):  # Check if the background music is already playing
             self.bg_music.play(-1)
             self.bg_music_playing = True
-            self.bg_music.set_volume(self.bgm_volume)
+            self.bg_music.set_volume(self.volume)
 
     def stop_bg_music(self):
         # Stop background music
@@ -59,6 +59,6 @@ class AudioPlayer:
 
     def handle_settings_change(self, event: Event):
         settings: Settings = event.target
+        self.set_volume(settings.master_volume / 100.0)
         self.set_bgm_volume(settings.bgm_volume / 100.0)
         self.set_effect_volume(settings.effect_volume / 100.0)
-        self.set_volume(settings.master_volume / 100.0)

--- a/game/ingame/ingamescene.py
+++ b/game/ingame/ingamescene.py
@@ -491,6 +491,7 @@ class InGameScene(Scene):
             start_position = other_player_entry.card_sprites[-1].absolute_rect.center
 
         animating_card_entity = CardEntity(card)
+        animating_card_entity.set_colorblind(self.world.settings.is_colorblind)
         animating_card_entity.rect.center = start_position
         self.discarding_card_entities.append(animating_card_entity)
         self.add_child(animating_card_entity)

--- a/game/ingame/ingamescene.py
+++ b/game/ingame/ingamescene.py
@@ -321,14 +321,12 @@ class InGameScene(Scene):
             pygame.Vector2(100, -175),
         )
         # 본인 이름 출력
-        self.name_font = get_font(FontType.UI_BOLD, 20)
-        self.name_text = Text(
-            me.name, pygame.Vector2(50, 10), self.name_font, pygame.Color("black")
+        name_font = get_font(FontType.UI_BOLD, 20)
+        name_text = Text(
+            me.name, pygame.Vector2(50, 10), name_font, pygame.Color("black")
         )
-        self.add_child(self.name_text)
-        self.layout.add(
-            self.name_text, LayoutAnchor.BOTTOM_CENTER, pygame.Vector2(0, -175)
-        )
+        self.add_child(name_text)
+        self.layout.add(name_text, LayoutAnchor.BOTTOM_CENTER, pygame.Vector2(0, -175))
 
         # 우노
         self.my_uno_text = Text(

--- a/game/ingame/ingamescene.py
+++ b/game/ingame/ingamescene.py
@@ -317,8 +317,17 @@ class InGameScene(Scene):
         )
         self.layout.add(
             self.mytimer_display,
-            LayoutAnchor.BOTTOM_LEFT,
-            pygame.Vector2(160, -50),
+            LayoutAnchor.BOTTOM_CENTER,
+            pygame.Vector2(100, -175),
+        )
+        # 본인 이름 출력
+        self.name_font = get_font(FontType.UI_BOLD, 20)
+        self.name_text = Text(
+            me.name, pygame.Vector2(50, 10), self.name_font, pygame.Color("black")
+        )
+        self.add_child(self.name_text)
+        self.layout.add(
+            self.name_text, LayoutAnchor.BOTTOM_CENTER, pygame.Vector2(0, -175)
         )
 
         # 우노
@@ -330,7 +339,7 @@ class InGameScene(Scene):
         )
         self.add_child(self.my_uno_text)
         self.layout.add(
-            self.my_uno_text, LayoutAnchor.BOTTOM_LEFT, pygame.Vector2(50, -50)
+            self.my_uno_text, LayoutAnchor.BOTTOM_CENTER, pygame.Vector2(-100, -175)
         )
 
         def update_uno_text(event: Event) -> None:

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -137,11 +137,9 @@ class Settings(EventEmitter):
             master_volume if master_volume is not None else self._master_volume
         )
         self._bgm_volume = bgm_volume if bgm_volume is not None else self._bgm_volume
-        self._bgm_volume = self._bgm_volume
         self._effect_volume = (
             effect_volume if effect_volume is not None else self._effect_volume
         )
-        self._effect_volume = self._effect_volume
 
         self.save()
         self.emit("change", Event(None))

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -137,11 +137,11 @@ class Settings(EventEmitter):
             master_volume if master_volume is not None else self._master_volume
         )
         self._bgm_volume = bgm_volume if bgm_volume is not None else self._bgm_volume
-        self._bgm_volume = self._master_volume * self._bgm_volume / 100
+        self._bgm_volume = self._bgm_volume
         self._effect_volume = (
             effect_volume if effect_volume is not None else self._effect_volume
         )
-        self._effect_volume = self._master_volume * self._effect_volume / 100
+        self._effect_volume = self._effect_volume
 
         self.save()
         self.emit("change", Event(None))

--- a/game/settings/settings.py
+++ b/game/settings/settings.py
@@ -23,6 +23,7 @@ DEFAULT_SETTINGS = {
     "height": 720,
     "is_colorblind": False,
     "keymap": DEFAULT_KEYMAP,
+    "master_volume": 100,
     "bgm_volume": 100,
     "effect_volume": 100,
 }
@@ -33,6 +34,7 @@ class Settings(EventEmitter):
     _height: int
     _is_colorblind: bool
     _keymap: KeyMap
+    _master_volume: int
     _bgm_volume: int
     _effect_volume: int
 
@@ -48,6 +50,7 @@ class Settings(EventEmitter):
                     "height": self.height,
                     "is_colorblind": self.is_colorblind,
                     "keymap": self.keymap,
+                    "master_volume": self.master_volume,
                     "bgm_volume": self.bgm_volume,
                     "effect_volume": self.effect_volume,
                 },
@@ -69,6 +72,7 @@ class Settings(EventEmitter):
                 height=value["height"],
                 is_colorblind=value["is_colorblind"],
                 keymap=value["keymap"],
+                master_volume=value["master_volume"],
                 bgm_volume=value["bgm_volume"],
                 effect_volume=value["effect_volume"],
             )
@@ -97,6 +101,10 @@ class Settings(EventEmitter):
         return self._keymap
 
     @property
+    def master_volume(self) -> int:
+        return self._master_volume
+
+    @property
     def bgm_volume(self) -> int:
         return self._bgm_volume
 
@@ -115,6 +123,7 @@ class Settings(EventEmitter):
         height: int | None = None,
         is_colorblind: bool | None = None,
         keymap: KeyMap | None = None,
+        master_volume: int | None = None,
         bgm_volume: int | None = None,
         effect_volume: int | None = None,
     ) -> None:
@@ -124,10 +133,15 @@ class Settings(EventEmitter):
             is_colorblind if is_colorblind is not None else self._is_colorblind
         )
         self._keymap = keymap if keymap is not None else self._keymap
+        self._master_volume = (
+            master_volume if master_volume is not None else self._master_volume
+        )
         self._bgm_volume = bgm_volume if bgm_volume is not None else self._bgm_volume
+        self._bgm_volume = self._master_volume * self._bgm_volume / 100
         self._effect_volume = (
             effect_volume if effect_volume is not None else self._effect_volume
         )
+        self._effect_volume = self._master_volume * self._effect_volume / 100
 
         self.save()
         self.emit("change", Event(None))

--- a/game/settings/settingscene.py
+++ b/game/settings/settingscene.py
@@ -85,6 +85,34 @@ class SettingScene(Scene):
             BUTTON_HEIGHT,
         )
         gap = 10
+
+        description_text = Text(
+            "Master Volume",
+            pygame.Vector2(0, 0),
+            self.font,
+            pygame.Color("black"),
+        )
+        self.add_child(description_text)
+        self.layout.add(
+            description_text, LayoutAnchor.TOP_LEFT, pygame.Vector2(50, 250 + 15)
+        )
+        for i, volume_value in enumerate(range(0, 100 + 1, 25)):
+            master_volume_button = Button(
+                f"{volume_value}%",
+                button_rect.copy(),
+                self.font,
+                lambda _, volume_value=volume_value: self.world.settings.set_values(
+                    effect_volume=volume_value, bgm_volume=volume_value
+                ),
+            )
+            self.add_child(master_volume_button)
+            self.layout.add(
+                master_volume_button,
+                LayoutAnchor.TOP_LEFT,
+                pygame.Vector2((button_width + gap) * i + 250, 250),
+            )
+            self.focus_controller.add(master_volume_button)
+
         description_text = Text(
             "BGM Volume",
             pygame.Vector2(0, 0),
@@ -93,7 +121,7 @@ class SettingScene(Scene):
         )
         self.add_child(description_text)
         self.layout.add(
-            description_text, LayoutAnchor.TOP_LEFT, pygame.Vector2(50, 250 + 15)
+            description_text, LayoutAnchor.TOP_LEFT, pygame.Vector2(50, 320 + 15)
         )
         for i, volume_value in enumerate(range(0, 100 + 1, 25)):
             bgm_volume_button = Button(
@@ -108,7 +136,7 @@ class SettingScene(Scene):
             self.layout.add(
                 bgm_volume_button,
                 LayoutAnchor.TOP_LEFT,
-                pygame.Vector2((button_width + gap) * i + 250, 250),
+                pygame.Vector2((button_width + gap) * i + 250, 320),
             )
             self.focus_controller.add(bgm_volume_button)
 
@@ -120,7 +148,7 @@ class SettingScene(Scene):
         )
         self.add_child(description_text)
         self.layout.add(
-            description_text, LayoutAnchor.TOP_LEFT, pygame.Vector2(50, 320 + 15)
+            description_text, LayoutAnchor.TOP_LEFT, pygame.Vector2(50, 390 + 15)
         )
         for i, volume_value in enumerate(range(0, 100 + 1, 25)):
             effect_volume_button = Button(
@@ -135,7 +163,7 @@ class SettingScene(Scene):
             self.layout.add(
                 effect_volume_button,
                 LayoutAnchor.TOP_LEFT,
-                pygame.Vector2((button_width + gap) * i + 250, 320),
+                pygame.Vector2((button_width + gap) * i + 250, 390),
             )
             self.focus_controller.add(effect_volume_button)
 
@@ -152,7 +180,7 @@ class SettingScene(Scene):
                 pygame.Color("black"),
             )
             self.layout.add(
-                description_text, LayoutAnchor.TOP_LEFT, pygame.Vector2(50, y + 15)
+                description_text, LayoutAnchor.TOP_LEFT, pygame.Vector2(50, y + 85)
             )
             self.add_child(description_text)
 
@@ -163,7 +191,7 @@ class SettingScene(Scene):
                 self.create_key_button_click_handler(dict_key),
             )
             self.layout.add(
-                change_key_button, LayoutAnchor.TOP_LEFT, pygame.Vector2(250, y)
+                change_key_button, LayoutAnchor.TOP_LEFT, pygame.Vector2(250, y + 70)
             )
             self.focus_controller.add(change_key_button)
             self.last_key_button = change_key_button

--- a/game/settings/settingscene.py
+++ b/game/settings/settingscene.py
@@ -102,7 +102,7 @@ class SettingScene(Scene):
                 button_rect.copy(),
                 self.font,
                 lambda _, volume_value=volume_value: self.world.settings.set_values(
-                    effect_volume=volume_value, bgm_volume=volume_value
+                    master_volume=volume_value
                 ),
             )
             self.add_child(master_volume_button)


### PR DESCRIPTION
1. 플레이어 자신의 이름을 출력하도록 변경하였습니다. 손패가 많아질 경우 왼쪽 UNO 표시, 이름 표시, 시간 표시와 겹치는 경우가 있어서 세개 다 손패 위로 위치를 수정하였습니다.

2. 카드를 내는 애니메이션 시 colorblind 색상이 적용되지 않는 버그를 수정하였습니다.

3. 전체볼륨인 master_volume을 추가했습니다. 다른 게임인 발로란트를 참고하여 기존 volume에 master_volume을 백분위 적용시켜 곱하는 연산으로 적용하였습니다.