### PR TITLE
색에 따른 카드모양 수정

### DIFF
--- a/game/gameplay/cardentitiy.py
+++ b/game/gameplay/cardentitiy.py
@@ -241,15 +241,10 @@ def draw_color_shape(surface: pygame.Surface, color: str) -> None:
     container_rect = surface.get_rect()
 
     if color == "red":
-        pygame.draw.polygon(
+        pygame.draw.ellipse(
             surface,
             (255, 255, 255),
-            [
-                [5, container_rect.centery],
-                [container_rect.centerx, container_rect.centery * 2 - 5],
-                [container_rect.centerx * 2 - 5, container_rect.centery],
-                [container_rect.centerx, 5],
-            ],
+            [10, 10, container_rect.centerx * 2 - 20, container_rect.centery * 2 - 20],
         )
     elif color == "yellow":
         pygame.draw.polygon(
@@ -272,10 +267,15 @@ def draw_color_shape(surface: pygame.Surface, color: str) -> None:
             ],
         )
     elif color == "blue":
-        pygame.draw.ellipse(
+        pygame.draw.polygon(
             surface,
             (255, 255, 255),
-            [10, 10, container_rect.centerx * 2 - 20, container_rect.centery * 2 - 20],
+            [
+                [5, container_rect.centery],
+                [container_rect.centerx, container_rect.centery * 2 - 5],
+                [container_rect.centerx * 2 - 5, container_rect.centery],
+                [container_rect.centerx, 5],
+            ],
         )
 
 


### PR DESCRIPTION
각 카드 색에 따라 [ 빨강 - 원 / 노랑 - 뒤집힌 삼각형 / 초록 - 삼각형 / 파랑 - 마름모 / 검정 - 없음 ] 순으로 pygame.draw를 사용하여 카드에 덮어썼습니다. 
기존에는 하얀색 선으로 테두리만 표시할까 했는데, 생각보다 지저분한 느낌이 들어서 현재는 도형 내부까지 하얗게 채웠습니다.