### PR TITLE
공격카드로 카드를 받았을 때 UNO가 풀리지 않던 것 및 UNO버튼 미입력 상태 회색으로 통일

### DIFF
--- a/game/gameplay/flow/drawcard.py
+++ b/game/gameplay/flow/drawcard.py
@@ -10,5 +10,4 @@ class DrawCardFlowNode(AbstractGameFlowNode):
     def enter(self) -> None:
         super().enter()
         self.game_state.draw_card(self.game_state.get_current_player())
-        self.game_state.unset_uno_clicked(self.game_state.get_current_player())
         self.machine.transition_to(EndTurnFlowNode(self.game_state))

--- a/game/gameplay/gamestate.py
+++ b/game/gameplay/gamestate.py
@@ -106,6 +106,7 @@ class GameState(EventEmitter):
                 return
         drawn_card = self.game_deck.draw()
         player.cards.append(drawn_card)
+        self.unset_uno_clicked(self.get_current_player())
         self.emit(
             GameStateEventType.PLAYER_EARNED_CARD,
             Event({"player": player, "card": drawn_card}),

--- a/game/ingame/ingamescene.py
+++ b/game/ingame/ingamescene.py
@@ -359,7 +359,7 @@ class InGameScene(Scene):
             self.my_uno_text.set_color(
                 pygame.Color("blue")
                 if self.get_me().is_unobutton_clicked
-                else pygame.Color("red")
+                else pygame.Color("gray")
             )
 
         self.game_state.on(

--- a/game/ingame/otherplayerentry.py
+++ b/game/ingame/otherplayerentry.py
@@ -159,7 +159,7 @@ class OtherPlayerEntry(GameObjectContainer):
         self.uno_text.set_color(
             pygame.Color("blue")
             if self.player.is_unobutton_clicked
-            else pygame.Color("red")
+            else pygame.Color("gray")
         )
 
     def handle_card_earned(self, event: Event) -> None:


### PR DESCRIPTION
공격카드로 카드를 받았을 때 UNO를 눌렀음을 표시해주는 파란색 글자가 빨간색 글자로 바뀌지 않던 것 수정 및 UNO를 누르지 않은 상태를 표시해주는 색깔을 회색으로 통일