### PR TITLE
업적이 달성됐을 때 실시간으로 반영하는 코드 추가 및 10턴 안에 승리 업적 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,4 +133,5 @@ dmypy.json
 
 # Project-specific
 settings.json
+achievements.json
 .DS_Store

--- a/engine/world.py
+++ b/engine/world.py
@@ -5,6 +5,7 @@ import tween
 
 from engine.events.event import Event
 from engine.scene import SceneDirector
+from game.achievements import Achievements
 from game.audio_player import AudioPlayer
 from game.settings.settings import Settings
 
@@ -15,6 +16,7 @@ class World:
     clock: pygame.time.Clock
     target_fps: float
     settings: Settings
+    achievements: Achievements
 
     def __init__(self, size: tuple[float, float], target_fps: float = 60) -> None:
         pygame.init()
@@ -26,6 +28,7 @@ class World:
         self.settings.on("change", self.handle_settings_change)
         self.audio_player = AudioPlayer(self.settings)
         self.audio_player.play_bg_music()
+        self.achievements = Achievements()
 
     def set_size(self, size: tuple[float, float]) -> None:
         self.screen = pygame.display.set_mode(size, pygame.RESIZABLE)

--- a/game/achievements.py
+++ b/game/achievements.py
@@ -1,0 +1,62 @@
+import json
+from typing import Any
+
+from engine.events.emitter import EventEmitter
+from engine.events.event import Event
+
+ACHIEVEMENTS_FILE_PATH = "achievements.json"
+DEFAULT_ACHIEVEMENTS = {
+    "win_less_10turn": [False, None],
+}
+
+
+class Achievements(EventEmitter):
+    _win_less_10turn: list
+
+    def __init__(self) -> None:
+        super().__init__()
+        pass
+
+    def save(self) -> None:
+        with open(ACHIEVEMENTS_FILE_PATH, "w") as f:
+            json.dump(
+                {
+                    "win_less_10turn": self.win_less_10turn,
+                },
+                f,
+            )
+
+    def load(self) -> None:
+        try:
+            with open(ACHIEVEMENTS_FILE_PATH) as f:
+                self.load_dict(json.load(f))
+        except FileNotFoundError:
+            print("기존 설정 파일을 찾지 못했습니다. 새 설정 파일을 만듭니다.")
+            self.reset()
+
+    def load_dict(self, value: dict[str, Any]) -> None:
+        try:
+            self.set_values(
+                win_less_10turn=value["win_less_10turn"],
+            )
+        except (AttributeError, KeyError) as e:
+            raise e
+            if value is DEFAULT_ACHIEVEMENTS:
+                print("기본 설정값을 불러오는 데 문제가 있습니다. 키값을 점검하세요.")
+            else:
+                print("저장된 설정을 불러오는 데 문제가 있어 기본 설정값으로 대체합니다.")
+                self.reset()
+
+    @property
+    def win_less_10turn(self) -> list:
+        return self._win_less_10turn
+
+    def set_values(
+        self,
+        win_less_10turn: list | None = None,
+    ) -> None:
+        self._win_less_10turn = (
+            win_less_10turn if win_less_10turn is not None else self._win_less_10turn
+        )
+        self.save()
+        self.emit("change", Event(target=self))

--- a/game/achievements.py
+++ b/game/achievements.py
@@ -31,7 +31,7 @@ class Achievements(EventEmitter):
             with open(ACHIEVEMENTS_FILE_PATH) as f:
                 self.load_dict(json.load(f))
         except FileNotFoundError:
-            print("기존 설정 파일을 찾지 못했습니다. 새 설정 파일을 만듭니다.")
+            print("기존 업적 파일을 찾지 못했습니다. 새 업적 파일을 만듭니다.")
             self.reset()
 
     def load_dict(self, value: dict[str, Any]) -> None:
@@ -42,9 +42,9 @@ class Achievements(EventEmitter):
         except (AttributeError, KeyError) as e:
             raise e
             if value is DEFAULT_ACHIEVEMENTS:
-                print("기본 설정값을 불러오는 데 문제가 있습니다. 키값을 점검하세요.")
+                print("기본 업적값을 불러오는 데 문제가 있습니다. 키값을 점검하세요.")
             else:
-                print("저장된 설정을 불러오는 데 문제가 있어 기본 설정값으로 대체합니다.")
+                print("저장된 업적을 불러오는 데 문제가 있어 기본 업적값으로 대체합니다.")
                 self.reset()
 
     @property

--- a/game/gameplay/flow/gameend.py
+++ b/game/gameplay/flow/gameend.py
@@ -1,3 +1,4 @@
+from engine.events.event import Event
 from game.gameplay.flow.abstractflownode import AbstractGameFlowNode
 from game.gameplay.gamestate import GameState
 
@@ -5,3 +6,15 @@ from game.gameplay.gamestate import GameState
 class GameEndFlowNode(AbstractGameFlowNode):
     def __init__(self, game_state: GameState) -> None:
         super().__init__(game_state)
+
+    def enter(self) -> None:
+        super().enter()
+        self.machine.events.emit(
+            "game_end",
+            Event(
+                {
+                    "turn": self.game_state.turn.current,
+                    "player": self.game_state.get_current_player(),
+                }
+            ),
+        )

--- a/game/gameplay/flow/gameend.py
+++ b/game/gameplay/flow/gameend.py
@@ -1,5 +1,6 @@
 from engine.events.event import Event
 from game.gameplay.flow.abstractflownode import AbstractGameFlowNode
+from game.gameplay.flow.gameflowmachine import GameFlowMachineEventType
 from game.gameplay.gamestate import GameState
 
 
@@ -10,7 +11,7 @@ class GameEndFlowNode(AbstractGameFlowNode):
     def enter(self) -> None:
         super().enter()
         self.machine.events.emit(
-            "game_end",
+            GameFlowMachineEventType.GAME_END,
             Event(
                 {
                     "turn": self.game_state.turn.current,

--- a/game/gameplay/flow/gameflowmachine.py
+++ b/game/gameplay/flow/gameflowmachine.py
@@ -12,6 +12,7 @@ class GameFlowMachineEventType(Enum):
     TRANSITION = "transition"
     TRANSITION_COMPLETE = "transition_complete"
     CARD_PLAYED = "card_played"
+    GAME_END = "game_end"
 
 
 class TransitionEvent(Event):

--- a/game/ingame/ingamescene.py
+++ b/game/ingame/ingamescene.py
@@ -133,7 +133,9 @@ class InGameScene(Scene):
         self.world.settings.on("change", lambda _: self.update_cards_colorblind)
 
         self.on("keydown", self.handle_keydown)
-        self.flow.events.on("game_end", self.check_win_less_10turn)
+        self.flow.events.on(
+            GameFlowMachineEventType.GAME_END, self.check_win_less_10turn
+        )
 
     def handle_color_change(self, event: TransitionEvent) -> None:
         is_turn_five = self.game_state.turn.total % 5 == 0

--- a/game/ingame/ingamescene.py
+++ b/game/ingame/ingamescene.py
@@ -1,4 +1,5 @@
 import random
+from datetime import datetime
 
 import pygame
 
@@ -132,6 +133,7 @@ class InGameScene(Scene):
         self.world.settings.on("change", lambda _: self.update_cards_colorblind)
 
         self.on("keydown", self.handle_keydown)
+        self.flow.events.on("game_end", self.check_win_less_10turn)
 
     def handle_color_change(self, event: TransitionEvent) -> None:
         is_turn_five = self.game_state.turn.total % 5 == 0
@@ -687,3 +689,9 @@ class InGameScene(Scene):
 
     def handle_focus_sound(self, event: Event) -> None:
         self.world.audio_player.play_effect_card_sliding()
+
+    def check_win_less_10turn(self, event: Event) -> None:
+        if event.data["turn"] <= 10 and event.data["player"] is self.get_me():
+            self.world.achievements.set_values(
+                win_less_10turn=[True, f"{datetime.now()}"]
+            )


### PR DESCRIPTION
각 업적이 달성될만한 노드에서 업적 달성 조건 체크에 필요한 정보를 보내주고
ingamescene의 각 함수에서 조건을 체크해 조건이 맞을 경우 achievements.py의 업적의 값을 바꿔줍니다.
10턴 안에 승리 업적 달성 시 달성 여부가 바뀌는 것과 달성 시간이 정상적으로 저장되는 것을 확인하였습니다.